### PR TITLE
Added YAML comparison by converting YAML string to JSON

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node src/app.js",
     "dev": "nodemon src/app.js",
+    "nomon": "node src/app.js",
     "resetdb": "cd src/db/ && dropdb broker --if-exists && createdb broker && NODE_ENV=development knex migrate:latest",
     "resetdb:seed": "cd src/db/ && dropdb broker --if-exists && createdb broker && NODE_ENV=development knex migrate:latest && NODE_ENV=development knex seed:run"
   },
@@ -21,7 +22,8 @@
     "object-hash": "^3.0.0",
     "objection": "^3.0.1",
     "pg": "^8.11.0",
-    "swagger-mock-validator": "^10.1.4"
+    "swagger-mock-validator": "^10.1.4",
+    "yaml": "^2.3.1"
   },
   "type": "module",
   "devDependencies": {

--- a/server/src/services/comparisonService.js
+++ b/server/src/services/comparisonService.js
@@ -1,78 +1,34 @@
-import Integration from "../models/Integration.js";
 import "dotenv/config";
-import fs from "node:fs";
-import knex from "../db/db.js";
 import Verifier from "./verification.js";
 import Comparison from "../models/Comparison.js";
-import { findOrCreate } from "../utils/queryHelpers.js";
 
 // export const comparisonQueue = [];
 
-const compare = async (integrationId) => {
-  const integration = await Integration.query()
-    .findById(integrationId)
-    .withGraphJoined("[consumer.contracts, provider.contracts]");
-
-  console.log(integration);
-
-  const { consumer, provider } = integration;
-
-  const consumerContracts = consumer.contracts;
-  const providerContracts = provider.contracts;
-
-  const comparisons = [];
-
+export const compare = async (
+  consumerContract,
+  providerContract,
+  integration
+) => {
   const verifier = new Verifier();
 
-  for (const consumerContract of consumerContracts) {
-    for (const providerContract of providerContracts) {
-      try {
-        const comparison = await verifier.verify(
-          consumerContract.contract.contractText,
-          providerContract.contract.contractText
-        );
-        comparisons.push({
-          ...comparison,
-          foo: "bar",
-          consumerContractId: consumerContract.contractId,
-          providerContractId: providerContract.contractId,
-        });
-      } catch (err) {
-        comparisons.push({
-          ...err,
-          foo: "bar",
-          consumerContractId: consumerContract.contractId,
-          providerContractId: providerContract.contractId,
-        });
-      }
-    }
+  try {
+    const result = await verifier.verify2(
+      consumerContract.contract.contractText,
+      providerContract.contract.contractText
+    );
+
+    const comparisonStatus = result.success ? "Success" : "Failed";
+
+    const comparison = await Comparison.query().insert({
+      integrationId: integration.integrationId,
+      consumerContractId: consumerContract.contractId,
+      providerContractId: providerContract.contractId,
+      result,
+      comparisonStatus: comparisonStatus,
+    });
+
+    return comparison;
+  } catch (err) {
+    console.log(err);
   }
-
-  let newComparisons = comparisons.map((comparison) =>
-    findOrCreate(
-      Comparison,
-      {
-        consumerContractId: comparison.consumerContractId,
-        providerContractId: comparison.providerContractId,
-        integrationId: integrationId,
-      },
-      {
-        consumerContractId: comparison.consumerContractId,
-        providerContractId: comparison.providerContractId,
-        integrationId: integrationId,
-        comparisonStatus: comparison.pass,
-      }
-    )
-  );
-
-  newComparisons = await Promise.all(newComparisons);
-
-  console.log("\n\ncomparisons:");
-  console.log(newComparisons);
-  console.log("\n\nend:");
-
-  fs.writeFileSync("comparisons.json", JSON.stringify(newComparisons, null, 2));
-  await knex.destroy();
 };
-
-compare(4);

--- a/server/src/services/verification.js
+++ b/server/src/services/verification.js
@@ -49,18 +49,22 @@ export default class Verifier {
   }
 
   async verify2(pact, openAPISpec) {
-    const [pactPath, OASPath] = await this.createFiles(pact, openAPISpec);
+    try {
+      const [pactPath, OASPath] = await this.createFiles(pact, openAPISpec);
 
-    const swaggerMockValidator = SwaggerMockValidatorFactory.create();
+      const swaggerMockValidator = SwaggerMockValidatorFactory.create();
 
-    const result = await swaggerMockValidator.validate({
-      mockPathOrUrl: pactPath,
-      specPathOrUrl: OASPath,
-    });
+      const result = await swaggerMockValidator.validate({
+        mockPathOrUrl: pactPath,
+        specPathOrUrl: OASPath,
+      });
 
-    this.cleanUpFiles(pactPath, OASPath);
+      this.cleanUpFiles(pactPath, OASPath);
 
-    return result;
+      return result;
+    } catch (err) {
+      console.log(err);
+    }
   }
 
   async createFiles(pact, openAPISpec) {


### PR DESCRIPTION
Initial comparison_service implementation. Requires the consumer contract to be published before the provider contract. Provider contract can be YAML or JSON but must follow OpenAPI schema. 